### PR TITLE
Cache Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ A simple app that tries to follow Clean Architecture, the SOLID principles and b
 * Dagger2 used to handle Dependency Injection.
 * Retrofit is used to get data from TheMovieDB API (v3)
 * Glide is used for image loading.
-* For testing the application, Mockito, jUnit4, assertJ and espresso are used.
+* For testing the application, Mockito, jUnit4, assertJ, Robolectric and espresso are used.
+* When there's no internet connection, results are loaded from Cache with Room and images are retrieved from Glide's Cache.
 
 <img src="app/appGifExample.gif" width="180" alt="App example Gif">
 

--- a/app/src/main/java/jdls/one/showmethemovies/main/MainActivity.kt
+++ b/app/src/main/java/jdls/one/showmethemovies/main/MainActivity.kt
@@ -71,7 +71,7 @@ class MainActivity : AppCompatActivity() {
   private fun setupScreenForError(message: String) {
     Log.e("Error", message) //In a real project we should send this error to Crashlytics.
     progress.gone()
-    viewEmpty.gone()
+    if (moviesAdapter.itemCount > 0) viewEmpty.gone() else viewEmpty.visible()
     recyclerView.showSnackbar(R.string.labelErrorResult) {
       action(R.string.labelTryAgain) { viewModel.fetchPopularTVShows() }
     }

--- a/app/src/main/java/jdls/one/showmethemovies/util/Extensions.kt
+++ b/app/src/main/java/jdls/one/showmethemovies/util/Extensions.kt
@@ -4,6 +4,7 @@ import android.view.View
 import android.widget.ImageView
 import androidx.annotation.StringRes
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.google.android.material.snackbar.Snackbar
 import jdls.one.showmethemovies.R
 
@@ -32,6 +33,7 @@ fun Snackbar.action(@StringRes actionRes: Int, color: Int? = null, listener: (Vi
 fun ImageView.loadImage(url: String?) {
   Glide.with(context)
     .load(url)
+    .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
     .error(R.color.colorSecondaryDark)
     .into(this)
 }

--- a/data/src/main/java/jdls/one/data/service/MoviesServiceFactory.kt
+++ b/data/src/main/java/jdls/one/data/service/MoviesServiceFactory.kt
@@ -40,8 +40,8 @@ object MoviesServiceFactory {
     return OkHttpClient.Builder()
         .addInterceptor(apiKeyInterceptor)
         .addInterceptor(httpLoggingInterceptor)
-        .connectTimeout(120, TimeUnit.SECONDS)
-        .readTimeout(120, TimeUnit.SECONDS)
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
         .build()
   }
 

--- a/data/src/main/java/jdls/one/data/source/MoviesCacheDataSource.kt
+++ b/data/src/main/java/jdls/one/data/source/MoviesCacheDataSource.kt
@@ -19,24 +19,19 @@ open class MoviesCacheDataSource @Inject constructor(
   }
 
   override fun getPopularTVShows(): Single<MovieResults> {
-    return Single.defer {
-      Single.just(movieDatabase.cachedMovieDao().getPopularTVShows())
-    }.map {
-      MovieResults(it.map { cachedMovie -> entityMapper.reverseMap(cachedMovie) }, 1)
-    }
+    return Single.just(movieDatabase.cachedMovieDao().getPopularTVShows())
+      .map {
+        MovieResults(it.map { cachedMovie -> entityMapper.reverseMap(cachedMovie) }, 1)
+      }
   }
 
   override fun saveMovie(movie: Movie): Completable {
-    return Completable.defer {
-      movieDatabase.cachedMovieDao().insertMovie(entityMapper.map(movie))
-      Completable.complete()
-    }
+    movieDatabase.cachedMovieDao().insertMovie(entityMapper.map(movie))
+    return Completable.complete()
   }
 
   override fun deleteMovies(): Completable {
-    return Completable.defer {
-      movieDatabase.cachedMovieDao().clearMovies()
-      Completable.complete()
-    }
+    movieDatabase.cachedMovieDao().clearMovies()
+    return Completable.complete()
   }
 }

--- a/data/src/test/java/jdls/one/data/repository/MoviesDataRepositoryTest.kt
+++ b/data/src/test/java/jdls/one/data/repository/MoviesDataRepositoryTest.kt
@@ -1,0 +1,75 @@
+package jdls.one.data.repository
+
+import com.nhaarman.mockitokotlin2.*
+import io.reactivex.Observable
+import io.reactivex.Single
+import jdls.one.data.source.MoviesApiDataSource
+import jdls.one.data.source.MoviesCacheDataSource
+import jdls.one.data.utils.anyMovieResults
+import jdls.one.domain.model.MovieResults
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.net.ConnectException
+import java.util.*
+
+@RunWith(JUnit4::class)
+class MoviesDataRepositoryTest {
+
+  private lateinit var apiDataSource: MoviesApiDataSource
+  private lateinit var cacheDataSource: MoviesCacheDataSource
+  private lateinit var moviesDataRepository: MoviesDataRepository
+
+
+  @Before
+  fun setUp() {
+    apiDataSource = mock()
+    cacheDataSource = mock()
+    moviesDataRepository = MoviesDataRepository(apiDataSource, cacheDataSource)
+  }
+
+  @Test
+  fun getPopularTVShowsCompletesUsingApiDataSource() {
+    whenever(apiDataSource.getPopularTVShows(Locale.getDefault().toString(), 1))
+      .doReturn(Single.just(anyMovieResults()))
+
+    val testObserver =
+      moviesDataRepository.getPopularTVShows(Locale.getDefault().toString(), 1).test()
+
+    testObserver.assertComplete()
+    testObserver.assertNoErrors()
+    testObserver.assertValueCount(1)
+    testObserver.dispose()
+    verify(apiDataSource, atLeastOnce()).getPopularTVShows(Locale.getDefault().toString(), 1)
+  }
+
+  @Test
+  fun getPopularTVShowsCompletesUsingCacheDataSource() {
+    val errorSingle = Observable.error<MovieResults>(ConnectException()).singleOrError()
+    whenever(apiDataSource.getPopularTVShows(Locale.getDefault().toString(), 1))
+      .doReturn(errorSingle)
+    whenever(cacheDataSource.getPopularTVShows()).doReturn(Single.just(anyMovieResults()))
+
+    val testObserver =
+      moviesDataRepository.getPopularTVShows(Locale.getDefault().toString(), 1).test()
+
+    testObserver.assertResult(anyMovieResults())
+    testObserver.dispose()
+    verify(cacheDataSource, atLeastOnce()).getPopularTVShows()
+  }
+
+  @Test
+  fun getPopularTVShowsReturnsErrorWhenExceptionIsNotConnectExceptionNorUnknownHostException() {
+    val errorSingle = Observable.error<MovieResults>(RuntimeException()).singleOrError()
+    whenever(apiDataSource.getPopularTVShows(Locale.getDefault().toString(), 1))
+      .doReturn(errorSingle)
+
+    val testObserver =
+      moviesDataRepository.getPopularTVShows(Locale.getDefault().toString(), 1).test()
+
+    testObserver.assertError(RuntimeException::class.java)
+    testObserver.dispose()
+    verify(cacheDataSource, never()).getPopularTVShows()
+  }
+}

--- a/data/src/test/java/jdls/one/data/source/MoviesCacheDataSourceTest.kt
+++ b/data/src/test/java/jdls/one/data/source/MoviesCacheDataSourceTest.kt
@@ -1,0 +1,72 @@
+package jdls.one.data.source
+
+import androidx.room.Room
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.atLeastOnce
+import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.verify
+import jdls.one.data.cache.db.MovieDatabase
+import jdls.one.data.mapper.CacheMapper
+import jdls.one.data.utils.anyMovie
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [23], manifest = Config.NONE)
+class MoviesCacheDataSourceTest {
+
+  private var movieDatabase =
+    Room.inMemoryDatabaseBuilder(RuntimeEnvironment.application, MovieDatabase::class.java)
+      .allowMainThreadQueries().build()
+  private var entityMapper = CacheMapper()
+
+  private var moviesCacheDataSource = MoviesCacheDataSource(movieDatabase, entityMapper)
+
+  @Test
+  fun saveMovieCompletes() {
+    val movie = anyMovie()
+
+    val testObserver = moviesCacheDataSource.saveMovie(movie).test()
+
+    testObserver.assertComplete()
+    testObserver.dispose()
+  }
+
+  @Test
+  fun deleteMoviesCompletes() {
+    val testObserver = moviesCacheDataSource.deleteMovies().test()
+
+    testObserver.assertComplete()
+    testObserver.dispose()
+  }
+
+  @Test
+  fun getPopularTVShowsCompletes() {
+    val testObserver = moviesCacheDataSource.getPopularTVShows().test()
+
+    testObserver.assertComplete()
+    testObserver.dispose()
+  }
+
+  @Test
+  fun getPopularTVShowsCallsEntityMapperReverseMap() {
+    entityMapper = spy(entityMapper)
+    moviesCacheDataSource = MoviesCacheDataSource(movieDatabase, entityMapper)
+
+    moviesCacheDataSource.saveMovie(anyMovie())
+    val testObserver = moviesCacheDataSource.getPopularTVShows().test()
+
+    testObserver.assertComplete()
+    testObserver.dispose()
+    verify(entityMapper, atLeastOnce()).reverseMap(any())
+  }
+
+  @Test
+  fun getDatabaseReturnsTheDatabase() {
+    assertEquals(movieDatabase, moviesCacheDataSource.getDatabase())
+  }
+}


### PR DESCRIPTION
### Work Done:
- Added Cache use: Now the data is persisted in cache when fetched from the API, so when there's no connection, we can use the data from cache and at least the app is usable.
- Improved Glide Cache policy: Selected the cache policy that best fit our needs.
- Reduce timeout times: Less time waiting for a better UX.
- Added tests for MoviesDataRepository and MoviesCacheDataSoruce.